### PR TITLE
Add lozad.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ A curated list of Web Performance Optimization. Everyone can contribute here!
 ## Lazyloaders
 
 * [lazyload](https://github.com/vvo/lazyload) - Lazyload images, iframes, widgets with a standalone JavaScript lazyloader ~1kb
+* [lozad.js](https://github.com/ApoorvSaxena/lozad.js) - Highly performant, light ~0.9kb and configurable lazy loader in pure JS with no dependencies for responsive images, iframes and more
 
 
 ## Loaders


### PR DESCRIPTION
The authors of [lazyload](https://github.com/vvo/lazyload) have the following notice at the top of the README:

> This library is still working but not actively maintained, we recommend you use [ApoorvSaxena/lozad.js](https://github.com/ApoorvSaxena/lozad.js) first rather than this one.