### PR TITLE
Add Speedrank

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Deprecated. This is deprecated and will be shut down in May 2019. Version 5 is t
 * [Varvy](https://varvy.com/pagespeed/) - Test your site to see if it follows the Google guidelines for speed.
 * [Web Bloat Score Calculator](http://www.webbloatscore.com/) - Compare size of a page to a compressed image of the same page
 * [Speed Racer](https://github.com/ngryman/speedracer) - Collect performance metrics for your library/application using Chrome headless.
+* [Speedrank](https://speedrank.app/) - Speedrank monitors the performance of your website in the background. It displays Lighthouse reports over time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
 
 ## Analyzers - API
 


### PR DESCRIPTION
Add Speedrank to the list of analyzers (tools).

Speedrank monitors the performance of your website in the background. It displays Lighthouse reports in time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.