### PR TITLE
Add ExifCleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Deprecated. This is deprecated and will be shut down in May 2019. Version 5 is t
 * [Sharp](https://github.com/lovell/sharp) - The typical use case for this high speed Node.js module is to convert large images of many formats to smaller, web-friendly JPEG, PNG and WebP images of varying dimensions.
 * [Gm](https://github.com/aheckmann/gm) - GraphicsMagick and ImageMagick for node.
 * [Exexif](https://github.com/h4cc/awesome-elixir) - Pure elixir library to extract tiff and exif metadata from jpeg files.
+* [ExifCleaner](https://exifcleaner.com) - GUI app to remove exif metadata from images and video files with drag and drop. Free and open source.
 * [OptiPNG](http://optipng.sourceforge.net/) - OptiPNG is a PNG optimizer that recompresses image files to a smaller size, without losing any information.
 * [Grunt-contrib-imagemin](https://github.com/gruntjs/grunt-contrib-imagemin) - Minify PNG and JPEG images for Grunt.
 * [Gulp-imagemin](https://github.com/sindresorhus/gulp-imagemin) - Minify PNG, JPEG, GIF and SVG images with imagemin for Gulp.


### PR DESCRIPTION
ExifCleaner is a free and open source GUI app to remove exif metadata from images and video with drag and drop. It's useful for reducing filesize a bit and anonymizing image files when building websites or other products. It's been out for a while now and I use it every day. I built it because I couldn't find any free and cross platform alternatives with such a simple workflow.