### PR TITLE
fix: Speedrank removed from Analyzers of Web Performance Optimization…

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -66,7 +66,6 @@ A curated list of Web Performance Optimization. Everyone can contribute here!
 - [Varvy](https://varvy.com/pagespeed/) - Test your site to see if it follows the Google guidelines for speed.
 - [Web Bloat Score Calculator](http://www.webbloatscore.com/) - Compare size of a page to a compressed image of the same page
 - [Speed Racer](https://github.com/ngryman/speedracer) - Collect performance metrics for your library/application using Chrome headless.
-- [Speedrank](https://speedrank.app/) - Speedrank monitors the performance of your site in the background. It displays Lighthouse reports over time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
 
 ## Analyzers - API
 


### PR DESCRIPTION
Web Performance Optimization

## Change
- Tool

## Description of changes
Removing Speedrank http://speedranking.app as is not working anymore (probably since november 26th of 2021)