### PR TITLE
Update Optimizt link & description

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Trimage](http://trimage.org/) - A cross-platform tool for losslessly optimizing PNG and JPG files.
 - [ImageEngine](https://imageengine.io) - Cloud service for optimizing, resizing and caching images on the fly with great mobile support.
 - [ImageKit.io](https://imagekit.io) - Intelligent real-time image optimizations, image transformations with a global delivery network and storage.
-- [Optimizt](https://github.com/funbox/optimizt) - CLI image optimization tool. It can compress PNG, JPEG, GIF and SVG lossy and lossless and create WebP versions for raster images.
+- [Optimizt](https://github.com/343dev/optimizt) - CLI image optimization tool. It can compress PNG, JPEG, GIF and SVG lossy and lossless, and also create AVIF and WebP versions for raster images.
 - [ResponsiveImage](https://responsive-image.dev/) - Generate optimized images (WebP, AVIF) and LQIP placeholders using Vite or webpack plugins and render responsive image markup with an image component for multiple frameworks.
 
 ## Lazyloaders


### PR DESCRIPTION
## Change
- Tool

## Description of changes
Hi. Optimizt has moved to a new repository. There’s a [notice](https://github.com/funbox/optimizt#-this-repo-is-unmaintained) about the move in the old repo, but I figured it’d be better to redirect users straight to the new one.

Also, Optimizt now supports AVIF image generation, so I’ve updated the description accordingly.