### PR TITLE
Add PageGym to Analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Here's a quick overview of the categories covered in this collection:
 ## Analyzers
 
 - [Web.dev](https://web.dev/) - Get the web's modern capabilities on your own sites and apps with useful guidance and analysis from web.dev.
-- [Page Gym](https://pagegym.com) - Advanced page speed analysis and optimization tool for experienced users and technical SEO professionals.
+- [PageGym](https://pagegym.com) - Advanced page speed analysis and optimization tool for experienced users and technical SEO professionals.
 - [Confess](https://github.com/jamesgpearce/confess) - Uses PhantomJS to headlessly analyze web pages and generate manifests.
 - [DebugBear](https://www.debugbear.com/) - DebugBear is a site monitoring tool based on Lighthouse. See how your scores and metrics changed over time, with a focus on understanding what caused each change. DebugBear is a paid product with a free 30-day trial.
 - [Page Speed](https://developers.google.com/speed/pagespeed/) - The PageSpeed family of tools is designed to help you optimize the performance of your site. PageSpeed Insights products will help you identify performance best practices that can be applied to your site, and PageSpeed optimization tools can help you automate the process.


### PR DESCRIPTION
## Change
- Tool

## Description of changes

This change adds Page Gym to the list of analyzers (it's a page speed analysis and optimization tool). It is one of the more technical tools on the list, and it's not based on lighthouse.