### PR TITLE
Add Redirect Checker - HTTP redirect chain analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Speed Racer](https://github.com/ngryman/speedracer) - Collect performance metrics for your library/application using Chrome headless.
 - [Speedrank](https://speedrank.app/) - Speedrank monitors the performance of your site in the background. It displays Lighthouse reports over time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
 - [Lightest App](https://lightest.app/) - Webpage load time is extremely important for conversion and revenue. Visualize web performance against competitors.
+- [Redirect Checker](https://github.com/brancogao/redirect-checker) - Analyze HTTP redirect chains, detect loops, and measure performance impact on page load times.
 
 ## Analyzers - API
 


### PR DESCRIPTION
## Description

Added [Redirect Checker](https://github.com/brancogao/redirect-checker) to the Analyzers section.

## What it does

Redirect Checker is an HTTP redirect chain analyzer that helps developers and SEO professionals:
- Trace complete redirect chains (301, 302, 307, 308)
- Detect redirect loops
- Measure performance impact at each hop
- Test with different User-Agents (Googlebot, Bingbot, Mobile, etc.)

## Why it fits

Redirect chains are a significant performance factor:
- Each redirect adds DNS lookup + TLS handshake + HTTP request latency
- Long redirect chains slow down page loads, especially on mobile
- SEO impact from diluted link equity

This tool helps identify and debug redirect performance issues.

## Checklist

- [x] The tool is free and open source
- [x] The tool is related to web performance optimization
- [x] The PR follows the existing format of the list