### PR TITLE
Add PageGuard - free all-in-one website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Speed Racer](https://github.com/ngryman/speedracer) - Collect performance metrics for your library/application using Chrome headless.
 - [Speedrank](https://speedrank.app/) - Speedrank monitors the performance of your site in the background. It displays Lighthouse reports over time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
 - [Lightest App](https://lightest.app/) - Webpage load time is extremely important for conversion and revenue. Visualize web performance against competitors.
+- [PageGuard](https://pageguard.org) - Free website health scanner analyzing performance, SEO, accessibility, and best practices with AI-generated action plans.
 
 ## Analyzers - API
 


### PR DESCRIPTION
## Add PageGuard to Analyzers section

PageGuard is a free web performance and health analyzer covering:
- Lighthouse-based performance metrics
- SEO technical analysis
- Accessibility (WCAG) checks
- Best practices audit
- AI-generated recommendations

Free, no signup required. REST API available.
https://pageguard.org