### PR TITLE
Remove Chrome Extension reference from Performance-Bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Here's a quick overview of the categories covered in this collection:
 - [PerfMap](https://github.com/zeman/perfmap) - A bookmarklet to create a frontend performance heatmap of resources loaded in the browser using the Resource Timing API.
 - [DOM Monster](https://github.com/madrobby/dom-monster) - A cross-platform, cross-browser bookmarklet that will analyze the DOM & other features of the page you're on, and give you its bill of health.
 - [CSS Stress](http://andy.edinborough.org/CSS-Stress-Testing-and-Performance-Profiling) - CSS Stress is a Testing and Performance Profiling.
-- [Performance-Bookmarklet](https://github.com/micmro/performance-bookmarklet) - Analyze the current page through the Resource Timing API, Navigation Timing API and User-Timing - Sort of a light live WebPageTest. As [Chrome Extension](https://chrome.google.com/webstore/detail/performance-analyser/djgfmlohefpomchfabngccpbaflcahjf?hl=en) and [Firefox Add-on](https://addons.mozilla.org/en-us/firefox/addon/performance-analyser/?src=cb-dl-created) under the name Performance-Analyser.
+- [Performance-Bookmarklet](https://github.com/micmro/performance-bookmarklet) - Analyze the current page through the Resource Timing API, Navigation Timing API and User-Timing - Sort of a light live WebPageTest. As [Firefox Add-on](https://addons.mozilla.org/en-us/firefox/addon/performance-analyser/?src=cb-dl-created) under the name Performance-Analyser.
 
 ## CDN
 


### PR DESCRIPTION
The Chrome extension for Performance-Bookmarklet is no longer available in the Chrome Web Store, so this PR updates the README to only list the Firefox Add-on under the name Performance-Analyser.

<img width="1144" height="320" alt="Screenshot 2026-03-11 at 8 26 30 PM" src="https://github.com/user-attachments/assets/f37a0795-80b3-475f-afda-062a6787918a" />

