### PR TITLE
docs: refresh curated performance links and agent skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Welcome to the curated list of Web Performance Optimization resources. This repo
 
 Here's a quick overview of the categories covered in this collection:
 
+- [Agent Skills](#agent-skills)
 - [Analyzers](README.md#analyzers)
 - [Analyzers API](README.md#analyzers---api)
 - [Application Performance Monitoring](#application-performance-monitoring)
@@ -53,6 +54,16 @@ Here's a quick overview of the categories covered in this collection:
 - [Stats](#stats)
 - [Other Awesome Lists](#other-awesome-lists)
 - [Contributing](#contributing)
+
+## Agent Skills
+
+> Agent skills for web quality audits and optimization workflows.
+
+- [web-quality-audit](https://github.com/addyosmani/web-quality-skills#web-quality-audit) - Comprehensive quality review across all categories.
+- [core-web-vitals](https://github.com/addyosmani/web-quality-skills#core-web-vitals) - LCP, INP, and CLS specific optimizations.
+- [accessibility](https://github.com/addyosmani/web-quality-skills#accessibility) - WCAG compliance, screen reader support, and keyboard navigation.
+- [performance](https://github.com/addyosmani/web-quality-skills#performance) - Loading speed, runtime efficiency, and resource optimization.
+- [best-practices](https://github.com/addyosmani/web-quality-skills#best-practices) - Security, modern APIs, and code quality patterns.
 
 ## Articles
 
@@ -85,6 +96,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Web Components in Action](https://www.manning.com/books/web-components-in-action) - Ben Farrell.
 - [Image Optimization](https://www.smashingmagazine.com/printed-books/image-optimization/) - Addy Osmani.
 - [Performance Engineering in Practice](https://www.manning.com/books/performance-engineering-in-practice) - Den Odell.
+- [Web Performance Engineering in the Age of AI](https://www.oreilly.com/library/view/web-performance-engineering/9798341660182/) - Addy Osmani.
 
 ## Case studies
 
@@ -131,14 +143,11 @@ Here's a quick overview of the categories covered in this collection:
 - [Web.dev](https://web.dev/) - Get the web's modern capabilities on your own sites and apps with useful guidance and analysis from web.dev.
 - [PageSpeed Insights](https://pagespeed.web.dev/) - Lab and field CWV diagnostics for any URL.
 - [PageGym](https://pagegym.com) - Advanced page speed analysis and optimization tool for experienced users and technical SEO professionals.
-- [Confess](https://github.com/jamesgpearce/confess) - Uses PhantomJS to headlessly analyze web pages and generate manifests.
 - [DebugBear](https://www.debugbear.com/) - Site monitoring based on Lighthouse. See how your scores and metrics changed over time, with a focus on understanding what caused each change. Paid product with a free 30-day trial.
 - [Page Speed](https://developers.google.com/speed) - The PageSpeed family of tools is designed to help you optimize the performance of your site. PageSpeed Insights products will help you identify performance best practices that can be applied to your site, and PageSpeed optimization tools can help you automate the process.
 - [Screpy](https://screpy.com) - AI-Based SEO Analysis & Monitoring Tool.
 - [YSlow](https://github.com/marcelduran/yslow) - Analyzes web pages and suggests ways to improve their performance based on a set of rules for high-performance web pages.
-- [YSlow for PhantomJS](https://yslow.org/phantomjs/) - PhantomJS build that adds new output formats for automated test frameworks: TAP (Test Anything Protocol) and JUnit.
 - [Grunt-WebPageTest](https://github.com/sideroad/grunt-wpt) - Grunt plugin for continuous measurement of WebPageTest. ([Demo](http://sideroad.github.io/sample-wpt-page/))
-- [Grunt-yslow](https://github.com/andyshora/grunt-yslow) - Grunt task for testing page performance using PhantomJS, a headless WebKit browser.
 - [Grunt-perfbudget](https://github.com/tkadlec/grunt-perfbudget) - A Grunt.js task for enforcing a performance budget ([more on performance budgets](https://timkadlec.com/2013/01/setting-a-performance-budget/)).
 - [Web Tracing Framework](https://github.com/google/tracing-framework) - Libraries, tools, and visualizers for tracing and investigating complex web applications.
 - [Yandex.Tank](https://github.com/yandex/yandex-tank) - An extensible open-source load testing tool for advanced Linux users which is especially good as a part of an automated load testing suite.
@@ -167,7 +176,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Atatus](https://www.atatus.com/) - Full-stack observability including RUM, APM, synthetic uptime, session replay, and OpenTelemetry.
 - [Datadog Real User Monitoring](https://www.datadoghq.com/product/real-user-monitoring/) - Browser and mobile RUM with session replay, Core Web Vitals, and correlation with traces and logs.
 - [New Relic Browser Monitoring](https://newrelic.com/platform/browser-monitoring) - Real-user browser monitoring with Core Web Vitals, distributed tracing to backend, and deployment markers.
-- [SpeedCurve](https://www.speedcurve.com/) - Web performance monitoring combining synthetic testing, RUM, Lighthouse, Core Web Vitals, performance budgets, and competitive benchmarking.
+- [SpeedCurve](https://www.speedcurve.com/features/performance-monitoring/) - Web performance monitoring combining synthetic testing, RUM, Lighthouse, Core Web Vitals, performance budgets, and competitive benchmarking.
 - [Boomerang (Open Source)](https://akamai.github.io/boomerang/oss/) - Documentation for the Open Source version of Boomerang, which is maintained by Akamai employees with contributions from the OSS community.
 - [Akamai mPulse Boomerang](https://techdocs.akamai.com/mpulse-boomerang/docs/welcome-to-mpulse-boomerang) - Documentation for the Akamai mPulse version of Boomerang, which includes additions specific to interacting with mPulse.
 
@@ -284,6 +293,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Grunt-WebP](https://github.com/somerandomdude/grunt-webp) - Convert your images to WebP format.
 - [Gulp-WebP](https://github.com/sindresorhus/gulp-webp) - Convert images to WebP for Gulp.
 - [Imageoptim](https://imageoptim.com/mac) - Free app that makes images take up less disk space and load faster, without sacrificing quality. It optimizes compression parameters, and removes junk metadata and unnecessary color profiles.
+- [Imager](http://github.com/imager-io/imager) - Automated image compression for efficiently distributing images on the web.
 - [Grunt-imageoptim](https://github.com/JamieMason/grunt-imageoptim) - Make ImageOptim, ImageAlpha, and JPEGmini part of your automated build process.
 - [ImageOptim-CLI](https://github.com/JamieMason/ImageOptim-CLI) - Automates ImageOptim, ImageAlpha, and JPEGmini for Mac to make batch optimization of images part of your automated build process.
 - [Tapnesh-CLI](https://github.com/JafarAkhondali/Tapnesh) - Tapnesh is a CLI tool that will optimize all your images in parallel easily and efficiently!
@@ -305,6 +315,7 @@ Here's a quick overview of the categories covered in this collection:
 
 - [lazyload](https://github.com/vvo/lazyload) - Defer images, iframes, and widgets with a standalone JavaScript lazyloader (~1kb).
 - [lozad.js](https://github.com/ApoorvSaxena/lozad.js) - Highly performant, light ~0.9kb, and configurable lazy loader in pure JS with no dependencies for responsive images, iframes, and more.
+- [quicklink](https://github.com/GoogleChromeLabs/quicklink) - Prefetch links in the viewport (via Intersection Observer) to make future navigations faster.
 
 ## Loaders
 
@@ -313,7 +324,9 @@ Here's a quick overview of the categories covered in this collection:
 - [Labjs](https://github.com/getify/LABjs) - An open-source (MIT license) project supported by Getify Solutions. The core purpose of LABjs is to be an all-purpose, on-demand JavaScript loader, capable of loading any JavaScript resource, from any location, into any page, at any time.
 - [Defer.js](https://github.com/wessman/defer.js) - Async Everything: Make the meat of your pages load faster with this JS morsel.
 - [InstantClick](https://github.com/dieulot/instantclick) - Preloads pages on hover so in-site links feel instant.
+- [prerender.js](https://github.com/genderev/prerender.js) - Preloads pages and assets ahead of navigation for faster page transitions.
 - [JIT](https://github.com/shootaroo/jit-grunt) - A JIT (Just In Time) plugin loader for Grunt. The load time of Grunt does not slow down even if there are many plugins.
+- [Guess.js](https://github.com/guess-js/guess) - Predictive prefetching and performance optimization using analytics and machine learning.
 
 ## Metrics Monitor
 
@@ -325,11 +338,13 @@ Here's a quick overview of the categories covered in this collection:
 - [Pingdom site Speed Test](https://tools.pingdom.com/) - Test the load time of that page, analyze it, and find bottlenecks.
 - [Dotcom-tools](https://www.dotcom-tools.com/website-speed-test) - Analyze your website's speed in real browsers from 20 locations worldwide.
 - [WebPageTest](https://www.catchpoint.com/webpagetest) - Run a free site speed test from multiple locations around the globe using real browsers (IE and Chrome) and at real consumer connection speeds. You can run simple tests or perform advanced testing including multi-step transactions, video capture, content blocking and much more. Your results will provide rich diagnostic information including resource-loading waterfall charts, Page Speed optimization checks and suggestions for improvements.
-- [Sitespeed.io](https://www.sitespeed.io/documentation/) - Open-source tool that checks your site against web performance best practices and uses the Navigation Timing API to collect metrics. Outputs XML and HTML reports.
+- [Sitespeed.io](https://www.sitespeed.io/) - Open-source tool that checks your site against web performance best practices and uses the Navigation Timing API to collect metrics. Outputs XML and HTML reports.
 - [Grunt-phantomas](https://github.com/stefanjudis/grunt-phantomas) - Grunt plugin wrapping phantomas to measure frontend performance.
 - [Perfjankie](https://www.npmjs.com/package/perfjankie) - Runtime Browser Performance regression suite ([Demo](https://github.com/asciidisco/perfjankie-test)).
 - [BrowserView Monitoring](https://www.dotcom-monitor.com/products/web-page-monitoring/) - Continually checks web page load times in Internet Explorer, Chrome and Firefox from multiple points around the world.
 - [DareBoost](https://www.dareboost.com/en) - Real Browser Monitoring. Offers complete reports about web performance and quality using YSlow, Page Speed and numerous custom tips.
+- [Perfume.js](https://github.com/Zizzamia/perfume.js) - Tiny library to collect Core Web Vitals and other performance metrics from real users.
+- [puppeteer-webperf](https://github.com/addyosmani/puppeteer-webperf) - Collect web performance metrics in Puppeteer scripts.
 
 ## Metrics Monitor - API
 

--- a/content/ARTICLES.md
+++ b/content/ARTICLES.md
@@ -31,6 +31,7 @@ path: /articles/
 - [Optimize LCP](https://web.dev/optimize-lcp/) - by web.dev
 - [Optimize CLS](https://web.dev/optimize-cls/) - by web.dev
 - [Optimize INP](https://web.dev/optimize-inp/) - by web.dev
+- [Core Web Vitals](https://addyosmani.com/blog/core-web-vitals/) - by Addy Osmani
 
 # Contributing
 


### PR DESCRIPTION
## Summary
- add an Agent Skills section to `README.md` and include it in the table of contents
- add requested modern tools/resources (quicklink, Guess.js, Perfume.js, puppeteer-webperf, Imager) and update Sitespeed/SpeedCurve URLs
- add new references (Addy Osmani Core Web Vitals article, O’Reilly book) and remove outdated PhantomJS-related entries (`Confess`, `YSlow for PhantomJS`, `Grunt-yslow`)

## Test plan
- [x] verify all requested links were added in appropriate sections
- [x] verify removed legacy tools no longer appear in `README.md`
- [x] verify `README.md` and `content/ARTICLES.md` pass lint checks