### PR TITLE
docs: add curated talks and performance references

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Here's a quick overview of the categories covered in this collection:
 - [Speed Racer](https://github.com/speedracer/speedracer) - Collect performance metrics for your library/application using Chrome headless.
 - [Lightest App](https://lightest.app/) - Webpage load time is extremely important for conversion and revenue. Visualize web performance against competitors.
 - [Redirect Checker](https://github.com/brancogao/redirect-checker) - Analyze HTTP redirect chains, detect loops, and measure performance impact on page load times.
+- [Third Party Analysis Tool](https://tools.paulcalvano.com/wpt-third-party-analysis/) - Analyze third-party request risk, render-blocking impact, and potential single points of failure from WebPageTest runs.
+- [Web Font Analyzer](https://tools.paulcalvano.com/wpt-font-analysis/) - Inspect font loading timing, payload, and glyph usage using WebPageTest data.
+- [Webfont Usage Analyzer](https://github.com/paulcalvano/webfont-usage-analyzer) - Bookmarklet script to map loaded web fonts to visible DOM usage and help spot font optimization opportunities.
 
 ## Analyzers - API
 

--- a/content/ARTICLES.md
+++ b/content/ARTICLES.md
@@ -32,6 +32,8 @@ path: /articles/
 - [Optimize CLS](https://web.dev/optimize-cls/) - by web.dev
 - [Optimize INP](https://web.dev/optimize-inp/) - by web.dev
 - [Core Web Vitals](https://addyosmani.com/blog/core-web-vitals/) - by Addy Osmani
+- [Third Parties and Single Points of Failure](https://paulcalvano.com/2025-12-29-third-parties-and-single-points-of-failure/) - by Paul Calvano
+- [Serving Static Content with Cloud Storage? Don't Forget the CDN!](https://paulcalvano.com/2026-02-09-serving-static-content-with-cloud-storage-dont-forget-the-cdn/) - by Paul Calvano
 
 # Contributing
 

--- a/content/TALKS.md
+++ b/content/TALKS.md
@@ -26,6 +26,14 @@ path: /talks/
 - 🇺🇸 **Site Performance Optimization - The Critical Rendering Path** by Udacity ~ [course](https://www.udacity.com/course/website-performance-optimization--ud884)
 - 🇬🇧 **Browser Rendering Optimization** by Udacity ~ [course](https://www.udacity.com/course/browser-rendering-optimization--ud860)
 - 🇺🇸 **Delivering the goods (2014)** by Paul Irish ~ [video](https://www.youtube.com/watch?v=R8W_6xWphtw) / [slides](https://docs.google.com/presentation/d/1MtDBNTH1g7CZzhwlJ1raEJagA8qM3uoV7ta6i66bO2M/present?slide=id.p19)
+- 🇺🇸 **The Hidden Performance Cost of Web Videos** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=unULkn9LuvE)
+- 🇺🇸 **Ad-Supported Sites Without the Slowdown** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=n_8YawtKSSk)
+- 🇺🇸 **7 Levels of a Web Performance Journey** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=tFzMOee0ymw)
+- 🇺🇸 **We Love LoAF and INP** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=_EMdFzLRkLM)
+- 🇺🇸 **Performance on a Budget: Lessons from Building a Nonprofit SaaS Platform** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=6ros6iNSdVU)
+- 🇺🇸 **Several Components are Rendering A Client Performance at Slack Scale** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=pf_4FQR_xtc)
+- 🇺🇸 **Flexible Architectures for Web Performance** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=aIfB12cQW9A)
+- 🇺🇸 **Font Performance** by NY Web Performance Meetup ~ [video](https://www.youtube.com/watch?v=Q_Vqpul5uIY)
 
 # Contributing
 


### PR DESCRIPTION
## Summary
- Add eight recent NY Web Performance Meetup talks to `content/TALKS.md`.
- Add two new Paul Calvano article references to `content/ARTICLES.md`.
- Add three tooling resources to the analyzers section in `README.md`.

## Test plan
- [x] Verify markdown formatting renders correctly.
- [x] Confirm all added links use valid URLs.
- [x] Ensure no unrelated files are included in the PR.