### PR TITLE
docs(content): add SPDY STREAM interviews page

### DIFF
--- a/content/INVERVIEWS.md
+++ b/content/INVERVIEWS.md
@@ -1,0 +1,43 @@
+---
+title: Inverviews
+author: Davidson Fellipe
+layout: post
+path: /inverviews/
+---
+
+# Inverviews
+
+> Interviews from the SPDY STREAM playlist
+
+## SPDY STREAM
+
+- **SPDY STREAM 031 w/ Patrick Meeman** ~ [video](https://www.youtube.com/watch?v=w1t2knnGeG4)
+- **SPDY STREAM 026 with Caleb Queern of KPMG** ~ [video](https://www.youtube.com/watch?v=d3de-7SqJjU)
+- **SPDY STREAM 025 with Jodie Chan of Chinafy** ~ [video](https://www.youtube.com/watch?v=f1p9Y3-IRAU)
+- **SPDY STREAM 024 | The JPEG XL with Jon Sneyers of Cloudinary** ~ [video](https://www.youtube.com/watch?v=3t2wYYnLctU)
+- **SPDY STREAM 023 with David Belson of Cloudflare: Cloudflare Radar 2025 Year in Review** ~ [video](https://www.youtube.com/watch?v=K58J992AZms)
+- **SPDY STREAM 022 with Arjen Karel. Launching a Fast and Free Personal Page.** ~ [video](https://www.youtube.com/watch?v=R8pzek-Fr7A)
+- **SPDY STREAM 021 with Marcy Sutton-Todd on Accessibility and Performance** ~ [video](https://www.youtube.com/watch?v=j0A0_5kchS0)
+- **SPDY STREAM 019 with Edwin Molina Hernandez of The Webperformance Report** ~ [video](https://www.youtube.com/watch?v=hLPhaEQCpjA)
+- **SPDY STREAM 018 with Matt Zeunert of DebugBear on Effective Monitoring** ~ [video](https://www.youtube.com/watch?v=0IWF6s_QnAY)
+- **SPDY STREAM 017 with Andrea Verlicchi of Speed Kit by Baqend** ~ [video](https://www.youtube.com/watch?v=8zGWE2G7Ylc)
+- **SPDY STREAM 016 with Amrik Malhans of Yottaa** ~ [video](https://www.youtube.com/watch?v=gtium4R3-nA)
+- **SPDY STREAM 015 with Nic Jansma and Robin Marx of Akamai** ~ [video](https://www.youtube.com/watch?v=rASXMFMwWn0)
+- **SPDY STREAM 014 with Philip Tellis of Akamai** ~ [video](https://www.youtube.com/watch?v=yoazDXRhlJU)
+- **SPDY STREAM 013 with Erik Witt of Speed Kit** ~ [video](https://www.youtube.com/watch?v=rz6mpodOPy4)
+- **SPDY STREAM 012 with Scott Jehl of SquareSpace** ~ [video](https://www.youtube.com/watch?v=ZDpOBStb_Os)
+- **SPDY STREAM 011 with with Mateusz Krzeszowiak and Yoav Weiss of Shopify** ~ [video](https://www.youtube.com/watch?v=DHgoULxvuJ8)
+- **SPDY STREAM 010 with Jacob Gross of Framer** ~ [video](https://www.youtube.com/watch?v=74VVztXy5RM)
+- **SPDY STREAM 009 with Weston Ruter** ~ [video](https://www.youtube.com/watch?v=HOfQT1G2VDI)
+- **SPDY STREAM 008 with Todd Gardner** ~ [video](https://www.youtube.com/watch?v=taf_FitzWNU)
+- **SPDY STREAM 007 with Tammy Everts of SpeedCuvre** ~ [video](https://www.youtube.com/watch?v=EygjSt5Gmmk)
+- **SPDY STREAM 006 with Cliff Crocker, Karlijn Lowik, Philip Tellis** ~ [video](https://www.youtube.com/watch?v=rXGqMbp2Ujk)
+- **SPDY STREAM 005 with Google's Felix Arntz** ~ [video](https://www.youtube.com/watch?v=knaDQ8KASp0)
+- **SPDY STREAM 004 with Shawn O'Neill** ~ [video](https://www.youtube.com/watch?v=LVDV3puF0mY)
+- **SPDY STREAM 003 with Akamai's Tim Vereecke and Robin Marx** ~ [video](https://www.youtube.com/watch?v=oWT_sqgGPCg)
+- **SPDY STREAM 002 w/ Dan Gayle of Shopify** ~ [video](https://www.youtube.com/watch?v=wnk6x6qqCSM)
+- **SPDY STREAM 001 w/ Guest Vinicius Dallacqua** ~ [video](https://www.youtube.com/watch?v=0Zzhhin79T8)
+
+# Contributing
+
+For contributing, [open an issue](https://github.com/davidsonfellipe/awesome-wpo/issues) and/or a [pull request](https://github.com/davidsonfellipe/awesome-wpo/pulls).


### PR DESCRIPTION
## Summary
- Add a new `content/INVERVIEWS.md` page for interview content.
- Populate the page with SPDY STREAM video entries from the provided playlist.
- Add a `SPDY STREAM` subsection and sort entries by latest stream number first.

## Test plan
- [x] Verify frontmatter and markdown heading structure matches existing content pages.
- [x] Confirm each entry links to the expected YouTube video URL.
- [x] Ensure only `content/INVERVIEWS.md` is included in this PR.