### PR TITLE
Add Lighthouse-MD to Analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Here's a quick overview of the categories covered in this collection:
 - [PageGym](https://pagegym.com) - Advanced page speed analysis and optimization tool for experienced users and technical SEO professionals.
 - [DebugBear](https://www.debugbear.com/) - Site monitoring based on Lighthouse. See how your scores and metrics changed over time, with a focus on understanding what caused each change. Paid product with a free 30-day trial.
 - [Page Speed](https://developers.google.com/speed) - The PageSpeed family of tools is designed to help you optimize the performance of your site. PageSpeed Insights products will help you identify performance best practices that can be applied to your site, and PageSpeed optimization tools can help you automate the process.
+- [Lighthouse-MD](https://lighthouse-md.com/) - Turn a PageSpeed Insights audit into a structured CLAUDE.md fix brief for Claude Code, with failing audits, offenders, prescriptive fixes, and a do-not-regress list.
 - [Dareboost](https://www.dareboost.com/) - [Multi-audit] Website quality testing across performance, accessibility, SEO, and security best practices.
 - [Screpy](https://screpy.com) - [Multi-audit] AI-based performance, SEO, uptime, and quality monitoring.
 - [YSlow](https://github.com/marcelduran/yslow) - Analyzes web pages and suggests ways to improve their performance based on a set of rules for high-performance web pages.


### PR DESCRIPTION
Adds [Lighthouse-MD](https://lighthouse-md.com/), a free tool that turns a PageSpeed Insights audit into a structured CLAUDE.md fix brief for Claude Code.

Placed under `## Analyzers`, right after the PageSpeed Insights family of tools where it logically groups.

What's in the generated CLAUDE.md:
- Every failing audit with measured value vs threshold
- The actual offender list per audit (scripts, DOM nodes, third-party origins)
- A prescriptive one-sentence fix per audit
- A "currently passing, do not break" section so an LLM-driven fix pass does not regress accessibility while chasing performance
- The test environment block (UA, throttling profile, host benchmark)

Free, no signup, no API key. Web app and Chrome extension share the same converter.

Disclosure: I am the author.

Lint: ran `npx awesome-lint`. My line (149) is clean. The 29 errors reported are pre-existing in the upstream README (TOC issues lines 27-51 and `[Multi-audit]` reference issues on Dareboost/Screpy entries), not introduced by this PR.