### PR TITLE
Add SiteRacer to Metrics Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Here's a quick overview of the categories covered in this collection:
 - [puppeteer-webperf](https://github.com/addyosmani/puppeteer-webperf) - Collect web performance metrics in Puppeteer scripts.
 - [WebPageTest API Wrapper for Node.js](https://github.com/catchpoint/WebPageTest.api-nodejs) - WebPageTest API Wrapper is an npm package that wraps WebPageTest API for Node.js as a module and a command-line tool.
 - [WebPerformance Report](https://webperformancereport.com/) - Web performance report every week in your inbox. Get a Personalized Report on the Status of the E-commerce or Website that you want to monitor in terms of Web performance and Web optimization, Core Web Vitals are included.
+- [SiteRacer](https://siteracer.com) - Free, no-signup tool to compare your website's speed (TTFB and page size) side-by-side against up to three competitors, with hosting, CDN and caching detection plus prioritized recommendations.
 
 ## Minifiers
 


### PR DESCRIPTION
Adds [SiteRacer](https://siteracer.com) to the Metrics Monitor section.

SiteRacer is a free, no-signup tool that benchmarks your site's load performance (response time/TTFB and page size) side-by-side against up to three competitors, detecting hosting, CDN and caching configuration to suggest prioritized fixes. It fits alongside the other hosted speed tools already in this section (GTmetrix, Pingdom site Speed Test, WebPageTest, Dotcom-tools). Single-line addition, format matched to existing entries.