### PR TITLE
chore: remove legacy Jekyll frontmatter from content files

### DIFF
--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -1,10 +1,3 @@
----
-title: Articles
-author: Davidson Fellipe
-layout: post
-path: /articles/
----
-
 # Articles
 
 > Articles about Web Performance Optimization

--- a/BLOGS.md
+++ b/BLOGS.md
@@ -1,10 +1,3 @@
----
-title: Articles
-author: Davidson Fellipe
-layout: post
-path: /blogs/
----
-
 # Blogs
 
 > Some blogs about Web Performance Optimization

--- a/INTERVIEWS.md
+++ b/INTERVIEWS.md
@@ -1,10 +1,3 @@
----
-title: Inverviews
-author: Davidson Fellipe
-layout: post
-path: /inverviews/
----
-
 # Inverviews
 
 > Interviews from the SPDY STREAM playlist

--- a/MEETUPS.md
+++ b/MEETUPS.md
@@ -1,10 +1,3 @@
----
-title: Articles
-author: Davidson Fellipe
-layout: post
-path: /meetups/
----
-
 # Meetups
 
 > Meetups about Web Performance Optimization

--- a/TALKS.md
+++ b/TALKS.md
@@ -1,10 +1,3 @@
----
-title: Talks
-author: Davidson Fellipe
-layout: post
-path: /talks/
----
-
 # Talks
 
 > Talks about Web Performance Optimization


### PR DESCRIPTION
## Summary
- Remove unused Jekyll-style frontmatter (`title`, `author`, `layout`, `path`) from `ARTICLES.md`, `BLOGS.md`, `INTERVIEWS.md`, `MEETUPS.md`, and `TALKS.md`
- Content files now start directly with their headings after the move to the repo root

## Test plan
- [x] Verify markdown files render correctly on GitHub
- [x] Confirm CI lint passes