### PR TITLE
docs: migrate blogs into ARTICLES.md

### DIFF
--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -10,6 +10,8 @@
 
 ## 2025
 
+- [Teaching Agents about Performance Insights](https://calendar.perfplanet.com/2025/teaching-agents-about-performance-insights/) - by Vinicius Dallacqua
+- [7 Steps of a Web Performance Journey](https://calendar.perfplanet.com/2025/7-steps-of-a-web-performance-journey/) - by Sergey Chernyshev, Eric Goldstein, Alexander Chernyshev
 - [How We Reduced Text Input Lag to Improve Web Performance: A Grammarly Case Study](https://www.grammarly.com/blog/engineering/reducing-text-input-lag/) - by Ankit Ahuja, Taras Polovyi
 - [Core Web Vitals](https://addyosmani.com/blog/core-web-vitals/) - by Addy Osmani
 - [Third Parties and Single Points of Failure](https://paulcalvano.com/2025-12-29-third-parties-and-single-points-of-failure/) - by Paul Calvano
@@ -64,6 +66,7 @@
 
 ## Undated
 
+- [Performance Calendar](https://calendar.perfplanet.com/) - by Stoyan Stefanov
 - [Fast](https://web.dev/fast/) - by web.dev
 - [Optimize LCP](https://web.dev/optimize-lcp/) - by web.dev
 - [Optimize CLS](https://web.dev/optimize-cls/) - by web.dev

--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -12,6 +12,7 @@
 
 - [Teaching Agents about Performance Insights](https://calendar.perfplanet.com/2025/teaching-agents-about-performance-insights/) - by Vinicius Dallacqua
 - [7 Steps of a Web Performance Journey](https://calendar.perfplanet.com/2025/7-steps-of-a-web-performance-journey/) - by Sergey Chernyshev, Eric Goldstein, Alexander Chernyshev
+- [Chrome DevTools for Debugging Web Performance](https://calendar.perfplanet.com/2025/chrome-devtools-for-debugging-web-performance/) - by Joan León
 - [How We Reduced Text Input Lag to Improve Web Performance: A Grammarly Case Study](https://www.grammarly.com/blog/engineering/reducing-text-input-lag/) - by Ankit Ahuja, Taras Polovyi
 - [Core Web Vitals](https://addyosmani.com/blog/core-web-vitals/) - by Addy Osmani
 - [Third Parties and Single Points of Failure](https://paulcalvano.com/2025-12-29-third-parties-and-single-points-of-failure/) - by Paul Calvano

--- a/BLOGS.md
+++ b/BLOGS.md
@@ -1,9 +1,0 @@
-# Blogs
-
-> Some blogs about Web Performance Optimization
-
-- 🇺🇸 **Performance Calendar** by Stoyan Stefanov ~ [https://calendar.perfplanet.com/](https://calendar.perfplanet.com/)
-
-# Contributing
-
-For contributing, [open an issue](https://github.com/davidsonfellipe/awesome-wpo/issues) and/or a [pull request](https://github.com/davidsonfellipe/awesome-wpo/pulls).

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Welcome to the curated list of Web Performance Optimization resources. This repo
 
 :memo: [Awesome WPO / Articles](#articles)
 
-:newspaper: [Awesome WPO / Blogs](#blogs)
-
 :books: [Awesome WPO / Books](#books)
 
 :book: [Awesome WPO / Docs](#documentation)
@@ -67,10 +65,6 @@ Here's a quick overview of the categories covered in this collection:
 ## Articles
 
 > Browse on [awesome-wpo.dev](https://awesome-wpo.dev/) or see [ARTICLES.md](ARTICLES.md).
-
-## Blogs
-
-> Browse on [awesome-wpo.dev](https://awesome-wpo.dev/) or see [BLOGS.md](BLOGS.md).
 
 ## Books
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "lint": "textlint --rule textlint-rule-terminology ./{ARTICLES,BLOGS,MEETUPS,TALKS,INTERVIEWS}.md",
+    "lint": "textlint --rule textlint-rule-terminology ./{ARTICLES,MEETUPS,TALKS,INTERVIEWS}.md",
     "lint-no-dead-link": "textlint --rule textlint-rule-no-dead-link *.md",
     "lint-awesome": "npx --yes awesome-lint README.md"
   },


### PR DESCRIPTION
## Summary
- Move Performance Calendar from `BLOGS.md` into the Undated section of `ARTICLES.md`
- Add two 2025 Performance Calendar articles
- Remove `BLOGS.md` and the Blogs section from README
- Update textlint paths in `package.json`

## Test plan
- [x] Verify README and ARTICLES.md render correctly on GitHub
- [x] Confirm CI lint passes