### PR TITLE
docs: move Lighthouse Agentic Browsing doc to ARTICLES.md

### DIFF
--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -17,6 +17,7 @@
 - [How We Reduced Text Input Lag to Improve Web Performance: A Grammarly Case Study](https://www.grammarly.com/blog/engineering/reducing-text-input-lag/) - by Ankit Ahuja, Taras Polovyi
 - [Core Web Vitals](https://addyosmani.com/blog/core-web-vitals/) - by Addy Osmani
 - [Third Parties and Single Points of Failure](https://paulcalvano.com/2025-12-29-third-parties-and-single-points-of-failure/) - by Paul Calvano
+- [Improving performance by prefetching product pages from Etsy Search](https://www.etsy.com/codeascraft/search-prefetching-performance) - by David Weinzimmer, Stoyan Stefanov
 
 ## 2024
 

--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -68,6 +68,7 @@
 ## Undated
 
 - [Performance Calendar](https://calendar.perfplanet.com/) - by Stoyan Stefanov
+- [Lighthouse Agentic Browsing scoring](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring) - by Chrome for Developers
 - [Fast](https://web.dev/fast/) - by web.dev
 - [Optimize LCP](https://web.dev/optimize-lcp/) - by web.dev
 - [Optimize CLS](https://web.dev/optimize-cls/) - by web.dev

--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -7,6 +7,7 @@
 - [Serving Static Content with Cloud Storage? Don't Forget the CDN!](https://paulcalvano.com/2026-02-09-serving-static-content-with-cloud-storage-dont-forget-the-cdn/) - by Paul Calvano
 - [Introducing Waterfall Tools](https://blog.patrickmeenan.com/2026/04/12/introducing-waterfall-tools/) - by Patrick Meenan
 - [How to use standard HTML video and audio lazy loading on the web today](https://engineering.squarespace.com/blog/2026/how-to-use-standard-html-video-and-audio-lazy-loading-on-the-web-today) - by Squarespace Engineering
+- [Lighthouse Agentic Browsing scoring](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring) - by Chrome for Developers
 
 ## 2025
 
@@ -68,7 +69,6 @@
 ## Undated
 
 - [Performance Calendar](https://calendar.perfplanet.com/) - by Stoyan Stefanov
-- [Lighthouse Agentic Browsing scoring](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring) - by Chrome for Developers
 - [Fast](https://web.dev/fast/) - by web.dev
 - [Optimize LCP](https://web.dev/optimize-lcp/) - by web.dev
 - [Optimize CLS](https://web.dev/optimize-cls/) - by web.dev

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Here's a quick overview of the categories covered in this collection:
 
 ## Events
 
+> Because community matters!
+
 ### Conferences
 
 - [We Love Speed](https://www.welovespeed.com/2024/) - Born from the desire to share knowledge and experiences in web performance as widely as possible.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Here's a quick overview of the categories covered in this collection:
 - [Best Practices for Speeding Up Your site](https://developer.yahoo.com/performance/rules.html) - The list includes 35 best practices divided into 7 categories, created by Yahoo! Exceptional Performance team.
 - [Chrome Developers: Performance](https://developer.chrome.com/docs/performance/) - Deep guides on rendering, loading, and runtime performance.
 - [Lighthouse Docs](https://developer.chrome.com/docs/lighthouse/) - Audit methodology, scoring details, and usage guidance.
-- [Lighthouse Agentic Browsing scoring](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring) - How the experimental Agentic Browsing category is evaluated (pass ratio, WebMCP, accessibility tree, CLS, llms.txt).
 - [Navigation Timing API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API) - Page navigation and load milestone metrics.
 - [Navigation Timing Level 2 (W3C)](https://www.w3.org/TR/navigation-timing-2/) - Use `responseStart` and `requestStart` to derive Time to First Byte (TTFB).
 - [Resource Timing API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Resource_Timing_API) - Detailed network timing for assets.
@@ -113,8 +112,6 @@ Here's a quick overview of the categories covered in this collection:
 - [Layout Instability API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/LayoutShift) - Measure and inspect layout shifts (CLS).
 
 ## Events
-
-> Because community matters!
 
 ### Conferences
 


### PR DESCRIPTION
## Summary
- Move Lighthouse Agentic Browsing scoring from README Documentation to `ARTICLES.md` (Undated section)
- Remove duplicate entry from README

## Test plan
- [x] Verify README and ARTICLES.md render correctly on GitHub
- [x] Confirm CI lint passes