### PR TITLE
docs: add curated performance articles and resources

### DIFF
--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -18,9 +18,11 @@
 - [Core Web Vitals](https://addyosmani.com/blog/core-web-vitals/) - by Addy Osmani
 - [Third Parties and Single Points of Failure](https://paulcalvano.com/2025-12-29-third-parties-and-single-points-of-failure/) - by Paul Calvano
 - [Improving performance by prefetching product pages from Etsy Search](https://www.etsy.com/codeascraft/search-prefetching-performance) - by David Weinzimmer, Stoyan Stefanov
+- [How We Achieved 75% Faster Builds by Removing Barrel Files](https://www.atlassian.com/blog/atlassian-engineering/faster-builds-when-removing-barrel-files) - by Tim Sebastian
 
 ## 2024
 
+- [Better Code Rendering Through Virtualization](https://blog.sentry.io/better-code-rendering-through-virtualization/) - by Nicholas Deschenes
 - [Enhancing The New York Times Web Performance with React 18](https://open.nytimes.com/enhancing-the-new-york-times-web-performance-with-react-18-d6f91a7c5af8) - by The New York Times
 - [Designed for delight, built for performance: The journey of pragmatic drag and drop](https://www.atlassian.com/blog/design/designed-for-delight-built-for-performance) - by Alex Reardon, Lewis Healey, Melissa Jaén, Maria Christley
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Best Practices for Speeding Up Your site](https://developer.yahoo.com/performance/rules.html) - The list includes 35 best practices divided into 7 categories, created by Yahoo! Exceptional Performance team.
 - [Chrome Developers: Performance](https://developer.chrome.com/docs/performance/) - Deep guides on rendering, loading, and runtime performance.
 - [Lighthouse Docs](https://developer.chrome.com/docs/lighthouse/) - Audit methodology, scoring details, and usage guidance.
+- [Code Splitting (Webpack)](https://webpack.js.org/guides/code-splitting/) - Official guide to splitting JavaScript bundles for faster initial load and on-demand loading.
 - [Navigation Timing API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API) - Page navigation and load milestone metrics.
 - [Navigation Timing Level 2 (W3C)](https://www.w3.org/TR/navigation-timing-2/) - Use `responseStart` and `requestStart` to derive Time to First Byte (TTFB).
 - [Resource Timing API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Resource_Timing_API) - Detailed network timing for assets.
@@ -299,6 +300,7 @@ Here's a quick overview of the categories covered in this collection:
 - [ImageKit.io](https://imagekit.io) - Intelligent real-time image optimizations, image transformations with a global delivery network and storage.
 - [Optimizt](https://github.com/343dev/optimizt) - CLI image optimization tool. It can compress PNG, JPEG, GIF and SVG lossy and lossless, and also create AVIF and WebP versions for raster images.
 - [ResponsiveImage](https://responsive-image.dev/) - Generate optimized images (WebP, AVIF) and LQIP placeholders using Vite or Webpack plugins and render responsive image markup with an image component for multiple frameworks.
+- [Adaptive Images](https://adaptive-images.com/) - Server-side PHP tool that detects screen size and automatically creates, caches, and delivers device-appropriate resized images from existing `<img>` markup.
 
 ## Lazyloaders
 
@@ -377,6 +379,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Critical](https://github.com/addyosmani/critical) - Extract & Inline Critical-path CSS in HTML pages (alpha).
 - [Csscolormin](https://github.com/stoyan/csscolormin) - Utility that minifies CSS colors, example: min("white"); // minifies to "#fff".
 - [Lazysizes](https://github.com/aFarkas/lazysizes) - High-performance lazy loader for images (responsive and normal), iframes, and scripts, that detects any visibility changes triggered through user interaction, CSS or JavaScript without configuration.
+- [react-virtualized](https://github.com/bvaughn/react-virtualized) - React components for efficiently rendering large lists and tabular data by virtualizing visible rows.
 - [TMI](https://github.com/addyosmani/tmi) - Too Many Images: discover your image weight on the web.
 
 ## SVG


### PR DESCRIPTION
## Summary
- Add two articles to `ARTICLES.md`: Sentry on code rendering virtualization (2024) and Atlassian on faster builds by removing barrel files (2025).
- Add three README resources: Webpack code splitting guide, Adaptive Images, and react-virtualized.

## Test plan
- [x] Verified links and entry format match existing list conventions
- [ ] CI checks pass