### PR TITLE
docs: update talks and articles with new entries and language fix

### DIFF
--- a/ARTICLES.md
+++ b/ARTICLES.md
@@ -30,6 +30,7 @@
 
 - [From Development to Real Users: How to Create a Web Performance Story](https://engineering.atspotify.com/2022/09/from-development-to-real-users-how-to-create-a-web-performance-story) - by Vinicius Teixeira Dallacqua
 - [DoorDash's Lessons on Improving Performance on High-Traffic Web Pages](https://careersatdoordash.com/blog/doordashs-lessons-on-improving-performance-on-high-traffic-web-pages/) - by Paipo Tang, David Nguyen
+- [Cloudflare Pages gets even faster with Early Hints](https://blog.cloudflare.com/early-hints-on-cloudflare-pages/) - by Greg Brimble
 
 ## 2021
 

--- a/TALKS.md
+++ b/TALKS.md
@@ -68,6 +68,7 @@
 
 ## 2021
 - [Portuguese] The Road to Web Performance Culture - Rafael Verger - BrazilJS CONF 2021 - by BrazilJS ~ [video](https://www.youtube.com/watch?v=Xmlg6g9dTPM)
+- [Spanish] Hacking Web Performance - by Maximiliano Firtman ~ [video](https://www.youtube.com/watch?v=dyABQXGgB7Y)
 
 ## 2020
 - [English] Core Web Vitals - What and how? - Ben Morss - 2020 ~ [video](https://www.youtube.com/watch?v=M_67ScoxYJY)

--- a/TALKS.md
+++ b/TALKS.md
@@ -87,7 +87,7 @@
 
 ### 2014
 - [Portuguese] Critical Rendering Path (2014) - by João Lucas P Santana ~ [slides](https://docs.google.com/presentation/d/1QbZpQklANUJn65yXdC-2uFTanK_rrjgs2YVnbw891iQ/edit?usp=sharing)
-- [Portuguese] Delivering the goods (2014) - by Paul Irish ~ [video](https://www.youtube.com/watch?v=R8W_6xWphtw) / [slides](https://docs.google.com/presentation/d/1MtDBNTH1g7CZzhwlJ1raEJagA8qM3uoV7ta6i66bO2M/present?slide=id.p19)
+- [English] Delivering the goods (2014) - by Paul Irish ~ [video](https://www.youtube.com/watch?v=R8W_6xWphtw) / [slides](https://docs.google.com/presentation/d/1MtDBNTH1g7CZzhwlJ1raEJagA8qM3uoV7ta6i66bO2M/present?slide=id.p19)
 - [English] CSS Performance Tooling (2014) - by Addy Osmani ~ [video](https://www.youtube.com/watch?v=FEs2jgZBaQA)
 - [Portuguese] O melhor da monitoração de Web Performance (2014) - by Davidson Fellipe ~ [video](https://www.youtube.com/watch?v=mHFuWVyxcTg) / [slides](https://www.slideshare.net/davidsonfellipe/o-melhor-da-monitoracao-de-web-performance)
 


### PR DESCRIPTION
## Summary
- Add the 2021 talk "Hacking Web Performance" by Maximiliano Firtman to `TALKS.md`
- Add the 2022 article "Cloudflare Pages gets even faster with Early Hints" by Greg Brimble to `ARTICLES.md`

## Test plan
- [x] Confirm the `TALKS.md` 2014 entry shows `[English]` for "Delivering the goods"
- [x] Confirm the 2021 Firtman talk appears under `## 2021` with the correct YouTube link
- [x] Confirm the Cloudflare Early Hints article appears under `## 2022` in `ARTICLES.md`
- [x] Run `git diff main...HEAD` and verify only the intended lines changed