### PR TITLE
Add Image Dimensions under Analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Web Font Analyzer](https://tools.paulcalvano.com/wpt-font-analysis/) - Inspect font loading timing, payload, and glyph usage using WebPageTest data.
 - [Webfont Usage Analyzer](https://github.com/paulcalvano/webfont-usage-analyzer) - Bookmarklet script to map loaded web fonts to visible DOM usage and help spot font optimization opportunities.
 - [Waterfall Tools](https://waterfall-tools.com/) - Advanced client-side network request waterfall viewer for HAR, WPT JSON, Chrome traces/netlogs, and tcpdump captures.
+- [Image Dimensions](https://imagedimensions.com/) - Scan any URL to find oversized images, comparing each image's natural and rendered dimensions to flag files downloaded much larger than they display. Also available as a CLI and GitHub Action for CI. Free, no signup.
 
 ## Analyzers - API
 


### PR DESCRIPTION
Adds **Image Dimensions** (https://imagedimensions.com) under Analyzers.

It scans any URL and compares each image's natural vs rendered dimensions to surface oversized images — files downloaded much larger than they display, a common Largest Contentful Paint problem. Free, no signup, and also available as a CLI (`imagedimensions-cli`) and GitHub Action for CI performance budgets.

Entry follows the `- [Name](url) - Description.` format.