### PR TITLE
Add PublishPixel to Image Optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Optimizt](https://github.com/343dev/optimizt) - CLI image optimization tool. It can compress PNG, JPEG, GIF and SVG lossy and lossless, and also create AVIF and WebP versions for raster images.
 - [ResponsiveImage](https://responsive-image.dev/) - Generate optimized images (WebP, AVIF) and LQIP placeholders using Vite or Webpack plugins and render responsive image markup with an image component for multiple frameworks.
 - [Adaptive Images](https://adaptive-images.com/) - Server-side PHP tool that detects screen size and automatically creates, caches, and delivers device-appropriate resized images from existing `<img>` markup.
+- [PublishPixel](https://publishpixel.net/website-image-optimizer) - Resize, compress, and convert images to WebP/AVIF in your browser to improve LCP and Core Web Vitals. Free, no upload.
 
 ## Lazyloaders
 


### PR DESCRIPTION
Adding PublishPixel — a free, privacy-first image optimizer that runs entirely in the browser (no upload, no signup). It resizes, compresses and converts images to WebP/AVIF to improve LCP and Core Web Vitals. Fits the Image Optimizers section. Thanks for maintaining this list!