### PR TITLE
Add MetaClean to Image Optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Here's a quick overview of the categories covered in this collection:
 - [Sharp](https://github.com/lovell/sharp) - The typical use case for this high-speed Node.js module is to convert large images of many formats to smaller, web-friendly JPEG, PNG, and WebP images of varying dimensions.
 - [Gm](https://github.com/aheckmann/gm) - GraphicsMagick and ImageMagick for Node.js.
 - [ExifCleaner](https://exifcleaner.com) - GUI app to remove EXIF metadata from images and video files with drag and drop. Free and open source.
+- [MetaClean](https://github.com/Moresyl/metaclean) - Cross-platform desktop app that removes image metadata entirely offline with drag and drop. Free and open source.
 - [OptiPNG](https://optipng.sourceforge.net/) - PNG optimizer that recompresses image files to a smaller size without losing information.
 - [Grunt-contrib-imagemin](https://github.com/gruntjs/grunt-contrib-imagemin) - Minify PNG and JPEG images for Grunt.
 - [Gulp-imagemin](https://github.com/sindresorhus/gulp-imagemin) - Minify PNG, JPEG, GIF and SVG images with imagemin for Gulp.


### PR DESCRIPTION
Adds MetaClean beside ExifCleaner in the Image Optimizers section. MetaClean is a free and open-source cross-platform desktop app that removes image metadata locally, so it directly matches the section's purpose of removing unnecessary image data without quality loss.

Validation:
- `git diff --check` passes.
- `pnpm install --frozen-lockfile` succeeds.
- `pnpm lint-awesome` was run; it reports 33 existing errors on lines 8–149, while the added entry is on line 282 and introduces no reported lint error.